### PR TITLE
adjust ulimit config in helm values

### DIFF
--- a/charts/localstack/values.template.yaml
+++ b/charts/localstack/values.template.yaml
@@ -3,10 +3,9 @@ image:
   tag: "$LOCALSTACK_IMAGE_TAG"
 
 command:
-  cmd:
-    - /bin/bash
-    - -c
-    - echo 'ulimit -Sn 32767' >> /root/.bashrc && echo 'ulimit -Su 16383' >> /root/.bashrc && docker-entrypoint.sh
+  - /bin/bash
+  - -c
+  - echo 'ulimit -Sn 32767' >> /root/.bashrc && echo 'ulimit -Su 16383' >> /root/.bashrc && docker-entrypoint.sh
 
 service:
   clusterIP: "10.100.0.42"


### PR DESCRIPTION
## Motivation
This PR is a heavy consumer of `localstack/helm-chart` (which is awesome!).
In this repo, some recently introduced changes (https://github.com/localstack/helm-charts/pull/104) will most likely be slightly changed with https://github.com/localstack/helm-charts/pull/107.
This PR contains the necessary changes to adjust to these changes.

## Changes
- Only removes the `cmd` sub-section in `command` in the `values.template.yaml`.